### PR TITLE
fix(ci): ensure version tag is captured for docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup Nodejs
         uses: actions/setup-node@v3
@@ -31,6 +33,9 @@ jobs:
         run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fetch all tags
+        run: git fetch --tags origin
 
       - name: Get the last tag via git and store in var
         id: step1


### PR DESCRIPTION
- Add fetch-depth: 0 to checkout to fetch full git history
- Add explicit git fetch --tags after semantic-release to ensure new tags are available
- This fixes the issue where app_version output was empty